### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Test build and package QubesOS RPMs
+
+on:
+  push:
+    branches:
+      - 'aem*'
+  pull_request_target:
+    branches: # this is to avoid running the workflow twice in a PR
+      - 'aem*'
+
+jobs:
+  qubes-dom0-package:
+    uses: TrenchBoot/.github/.github/workflows/qubes-dom0-package.yml@master
+    with:
+      base-commit: 'cbb35e72802f3a285c382a995ef647b59e5caf2f'
+      patch-start: 1300
+      qubes-component: 'vmm-xen'
+      spec-pattern: '/^Patch1202:/'


### PR DESCRIPTION
Automatically build `aem*` branches and pull requests by making a list of patches, putting them into `qubes-src/vmm-xen/`, updating spec-file and building the component to get RPM packages.

Mind that actions first need to be enabled on this repository.