### PR TITLE
x86/boot: generate value of size field in MLE header

### DIFF
--- a/xen/arch/x86/boot/head.S
+++ b/xen/arch/x86/boot/head.S
@@ -126,7 +126,7 @@ mle_header:
         .long   (slaunch_stub_entry - start)  /* Linear entry point of MLE (SINIT virt. address) */
         .long   0x00000000  /* First valid page of MLE */
         .long   0x00000000  /* Offset within binary of first byte of MLE */
-        .long   0x00000000  /* Offset within binary of last byte + 1 of MLE (set by loader) */
+        .long   (_end - start)  /* Offset within binary of last byte + 1 of MLE */
         .long   0x00000223  /* Bit vector of MLE-supported capabilities */
         .long   0x00000000  /* Starting linear address of command line (unused) */
         .long   0x00000000  /* Ending linear address of command line (unused) */


### PR DESCRIPTION
Do not rely on bootloader to do that to avoid discrepancies between measured data and binary file that's being loaded.

***

Alternatively, `aem-phase3-rebase` can be force-pushed as `aem`.

Prompted by https://github.com/QubesOS/qubes-vmm-xen/pull/160#discussion_r1501158410