### PR TITLE
Support AMD SKINIT for Slaunch boot

### DIFF
--- a/xen/arch/x86/Makefile
+++ b/xen/arch/x86/Makefile
@@ -59,6 +59,7 @@ obj-y += psr.o
 obj-y += intel_txt.o
 obj-y += setup.o
 obj-y += shutdown.o
+obj-y += slaunch.o
 obj-y += smp.o
 obj-y += smpboot.o
 obj-y += spec_ctrl.o

--- a/xen/arch/x86/boot/Makefile
+++ b/xen/arch/x86/boot/Makefile
@@ -1,6 +1,6 @@
 obj-bin-y += head.o
 
-head-bin-objs := cmdline.o reloc.o txt_early.o tpm_early.o
+head-bin-objs := cmdline.o reloc.o slaunch_early.o tpm_early.o
 
 nocov-y   += $(head-bin-objs)
 noubsan-y += $(head-bin-objs)

--- a/xen/arch/x86/boot/head.S
+++ b/xen/arch/x86/boot/head.S
@@ -522,21 +522,33 @@ __start:
         jmp     trampoline_bios_setup
 
 .Lslaunch_proto:
+        /* Upon reaching here, CPU state mostly matches the one setup by the
+         * bootloader with ESP, ESI and EDX being clobbered above. */
+
         /* Save information that TrenchBoot slaunch was used. */
         movb    $1, sym_esi(slaunch_active)
 
-        /* Push arguments to stack and call txt_early_tests(). */
+        /* Prepare space for output parameter of slaunch_early_tests(), which is
+         * a structure of two uint32_t fields. */
+        sub     $8, %esp
+
+        /* Push arguments to stack and call slaunch_early_tests(). */
+        push    %esp                        /* pointer to output structure */
         push    $sym_offs(__2M_rwdata_end)  /* end of target image */
         push    $sym_offs(_start)           /* target base address */
         push    %esi                        /* load base address */
-        call    txt_early_tests
+        call    slaunch_early_tests
 
-        /*
-         * txt_early_tests() returns MBI address, pass it to tpm_extend_mbi()
-         * and store for later in EBX.
-         */
-        push    %eax
-        movl    %eax,%ebx
+        /* Move outputs of slaunch_early_tests() from stack into registers. */
+        pop     %ebx  /* physical MBI address */
+        pop     %edx  /* physical SLRT address */
+
+        /* Save physical address of SLRT for C code. */
+        mov     %edx, sym_esi(slaunch_slrt)
+
+        /* Push arguments to stack and call tpm_extend_mbi(). */
+        push    %edx  /* SLRT address because early code has no slaunch_slrt */
+        push    %ebx  /* MBI address */
         call    tpm_extend_mbi
 
         /* Move magic number expected by Multiboot 2 to EAX and fall through. */
@@ -864,8 +876,8 @@ reloc:
         .incbin "reloc.bin"
 
         ALIGN
-txt_early_tests:
-        .incbin "txt_early.bin"
+slaunch_early_tests:
+        .incbin "slaunch_early.bin"
 
         ALIGN
 tpm_extend_mbi:

--- a/xen/arch/x86/boot/head.S
+++ b/xen/arch/x86/boot/head.S
@@ -534,6 +534,8 @@ __start:
 
         /* Push arguments to stack and call slaunch_early_tests(). */
         push    %esp                        /* pointer to output structure */
+        push    %ebp                        /* Slaunch parameter on AMD */
+        push    %ebx                        /* Multiboot parameter */
         push    $sym_offs(__2M_rwdata_end)  /* end of target image */
         push    $sym_offs(_start)           /* target base address */
         push    %esi                        /* load base address */

--- a/xen/arch/x86/boot/slaunch_early.c
+++ b/xen/arch/x86/boot/slaunch_early.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 3mdeb Sp. z o.o. All rights reserved.
+ * Copyright (c) 2022-2024 3mdeb Sp. z o.o. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,11 +23,18 @@ asm (
     "    .text                         \n"
     "    .globl _start                 \n"
     "_start:                           \n"
-    "    jmp  txt_early_tests          \n"
+    "    jmp  slaunch_early_tests      \n"
     );
 
 #include "defs.h"
 #include "../include/asm/intel_txt.h"
+#include "../include/asm/slaunch.h"
+
+struct early_tests_results
+{
+    uint32_t mbi_pa;
+    uint32_t slrt_pa;
+} __packed;
 
 static void verify_pmr_ranges(struct txt_os_mle_data *os_mle,
                               struct txt_os_sinit_data *os_sinit,
@@ -104,9 +111,10 @@ static void verify_pmr_ranges(struct txt_os_mle_data *os_mle,
     */
 }
 
-uint32_t __stdcall txt_early_tests(uint32_t load_base_addr,
+void __stdcall slaunch_early_tests(uint32_t load_base_addr,
                                    uint32_t tgt_base_addr,
-                                   uint32_t tgt_end_addr)
+                                   uint32_t tgt_end_addr,
+                                   struct early_tests_results *result)
 {
     void *txt_heap;
     struct txt_os_mle_data *os_mle;
@@ -127,5 +135,6 @@ uint32_t __stdcall txt_early_tests(uint32_t load_base_addr,
 
     verify_pmr_ranges(os_mle, os_sinit, load_base_addr, tgt_base_addr, size);
 
-    return os_mle->boot_params_addr;
+    result->mbi_pa = os_mle->boot_params_addr;
+    result->slrt_pa = os_mle->slrt;
 }

--- a/xen/arch/x86/cpu/common.c
+++ b/xen/arch/x86/cpu/common.c
@@ -15,7 +15,7 @@
 #include <asm/apic.h>
 #include <asm/random.h>
 #include <asm/setup.h>
-#include <asm/intel_txt.h>
+#include <asm/slaunch.h>
 #include <asm/shstk.h>
 #include <mach_apic.h>
 #include <public/sysctl.h> /* for XEN_INVALID_{SOCKET,CORE}_ID */

--- a/xen/arch/x86/cpu/common.c
+++ b/xen/arch/x86/cpu/common.c
@@ -15,6 +15,7 @@
 #include <asm/apic.h>
 #include <asm/random.h>
 #include <asm/setup.h>
+#include <asm/intel_txt.h>
 #include <asm/shstk.h>
 #include <mach_apic.h>
 #include <public/sysctl.h> /* for XEN_INVALID_{SOCKET,CORE}_ID */
@@ -977,6 +978,13 @@ void cpu_init(void)
 	write_debugreg(3, 0);
 	write_debugreg(6, X86_DR6_DEFAULT);
 	write_debugreg(7, X86_DR7_DEFAULT);
+
+	/*
+	 * If the platform is performing a Secure Launch via TXT, secondary
+	 * CPUs (APs) will need to be woken up in a TXT-specific way.
+	 */
+	if ( slaunch_active && boot_cpu_data.x86_vendor == X86_VENDOR_INTEL )
+		ap_boot_method = AP_BOOT_TXT;
 
 	/*
 	 * If the platform is performing a Secure Launch via SKINIT, GIF is

--- a/xen/arch/x86/e820.c
+++ b/xen/arch/x86/e820.c
@@ -12,6 +12,7 @@
 #include <asm/msr.h>
 #include <asm/guest.h>
 #include <asm/intel_txt.h>
+#include <asm/slaunch.h>
 
 /*
  * opt_mem: Limit maximum address of physical RAM.

--- a/xen/arch/x86/e820.c
+++ b/xen/arch/x86/e820.c
@@ -457,7 +457,7 @@ static uint64_t __init mtrr_top_of_ram(void)
     rdmsrl(MSR_MTRRcap, mtrr_cap);
     rdmsrl(MSR_MTRRdefType, mtrr_def);
 
-    if ( slaunch_active )
+    if ( slaunch_active && boot_cpu_data.x86_vendor == X86_VENDOR_INTEL )
         txt_restore_mtrrs(e820_verbose);
 
     if ( e820_verbose )

--- a/xen/arch/x86/include/asm/intel_txt.h
+++ b/xen/arch/x86/include/asm/intel_txt.h
@@ -322,14 +322,6 @@ static inline int is_in_pmr(struct txt_os_sinit_data *os_sinit, uint64_t base,
     return 0;
 }
 
-/* Returns physical address. */
-static inline uint32_t txt_find_slrt(void)
-{
-    struct txt_os_mle_data *os_mle =
-        txt_os_mle_data_start(_txt(read_txt_reg(TXTCR_HEAP_BASE)));
-    return os_mle->slrt;
-}
-
 extern void map_txt_mem_regions(void);
 extern void protect_txt_mem_regions(void);
 extern void txt_restore_mtrrs(bool e820_verbose);

--- a/xen/arch/x86/include/asm/intel_txt.h
+++ b/xen/arch/x86/include/asm/intel_txt.h
@@ -1,5 +1,3 @@
-#include <xen/multiboot.h>
-
 /*
  * TXT configuration registers (offsets from TXT_{PUB, PRIV}_CONFIG_REGS_BASE)
  */
@@ -80,8 +78,6 @@
 
 #ifndef __ASSEMBLY__
 
-extern bool slaunch_active;
-
 extern char txt_ap_entry[];
 extern uint32_t trampoline_gdt[];
 
@@ -93,8 +89,6 @@ extern uint32_t trampoline_gdt[];
 #include <asm/page.h>   // __va()
 #define _txt(x) __va(x)
 #endif
-
-#include <xen/slr_table.h>
 
 /*
  * Always use private space as some of registers are either read-only or not
@@ -328,36 +322,6 @@ static inline int is_in_pmr(struct txt_os_sinit_data *os_sinit, uint64_t base,
     return 0;
 }
 
-/*
- * This helper function is used to map memory using L2 page tables by aligning
- * mapped regions to 2MB. This way page allocator (which at this point isn't
- * yet initialized) isn't needed for creating new L1 mappings. The function
- * also checks and skips memory already mapped by the prebuilt tables.
- *
- * There is no unmap_l2() because the function is meant to be used for code that
- * accesses TXT registers and TXT heap soon after which Xen rebuilds memory
- * maps, effectively dropping all existing mappings.
- */
-extern int map_l2(unsigned long paddr, unsigned long size);
-
-/* evt_log is a physical address and the caller must map it to virtual, if
- * needed. */
-static inline void find_evt_log(struct slr_table *slrt, void **evt_log,
-                                uint32_t *evt_log_size)
-{
-    struct slr_entry_log_info *log_info;
-
-    log_info = (struct slr_entry_log_info *)
-        slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
-    if ( log_info != NULL ) {
-        *evt_log = _p(log_info->addr);
-        *evt_log_size = log_info->size;
-    } else {
-        *evt_log = NULL;
-        *evt_log_size = 0;
-    }
-}
-
 /* Returns physical address. */
 static inline uint32_t txt_find_slrt(void)
 {
@@ -369,31 +333,5 @@ static inline uint32_t txt_find_slrt(void)
 extern void map_txt_mem_regions(void);
 extern void protect_txt_mem_regions(void);
 extern void txt_restore_mtrrs(bool e820_verbose);
-
-#define DRTM_LOC                   2
-#define DRTM_CODE_PCR              17
-#define DRTM_DATA_PCR              18
-
-/*
- * Secure Launch event log entry type. The TXT specification defines the
- * base event value as 0x400 for DRTM values.
- */
-#define TXT_EVTYPE_BASE            0x400
-#define TXT_EVTYPE_SLAUNCH         (TXT_EVTYPE_BASE + 0x102)
-#define TXT_EVTYPE_SLAUNCH_START   (TXT_EVTYPE_BASE + 0x103)
-#define TXT_EVTYPE_SLAUNCH_END     (TXT_EVTYPE_BASE + 0x104)
-
-void tpm_hash_extend(unsigned loc, unsigned pcr, uint8_t *buf, unsigned size,
-                     uint32_t type, uint8_t *log_data, unsigned log_data_size);
-
-/* Measures essential parts of SLR table before making use of them. */
-void tpm_measure_slrt(void);
-
-/* Takes measurements of DRTM policy entries except for MBI and SLRT which
- * should have been measured by the time this is called. Also performs sanity
- * checks of the policy and panics on failure. In particular, the function
- * verifies that DRTM is consistent with MultibootInfo (MBI) (the MBI address
- * is assumed to be virtual). */
-void tpm_process_drtm_policy(const multiboot_info_t *mbi);
 
 #endif /* __ASSEMBLY__ */

--- a/xen/arch/x86/include/asm/intel_txt.h
+++ b/xen/arch/x86/include/asm/intel_txt.h
@@ -342,14 +342,10 @@ extern int map_l2(unsigned long paddr, unsigned long size);
 
 /* evt_log is a physical address and the caller must map it to virtual, if
  * needed. */
-static inline void find_evt_log(void **evt_log, uint32_t *evt_log_size)
+static inline void find_evt_log(struct slr_table *slrt, void **evt_log,
+                                uint32_t *evt_log_size)
 {
-    struct txt_os_mle_data *os_mle;
-    struct slr_table *slrt;
     struct slr_entry_log_info *log_info;
-
-    os_mle = txt_os_mle_data_start(_txt(read_txt_reg(TXTCR_HEAP_BASE)));
-    slrt = _txt(os_mle->slrt);
 
     log_info = (struct slr_entry_log_info *)
         slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
@@ -360,6 +356,14 @@ static inline void find_evt_log(void **evt_log, uint32_t *evt_log_size)
         *evt_log = NULL;
         *evt_log_size = 0;
     }
+}
+
+/* Returns physical address. */
+static inline uint32_t txt_find_slrt(void)
+{
+    struct txt_os_mle_data *os_mle =
+        txt_os_mle_data_start(_txt(read_txt_reg(TXTCR_HEAP_BASE)));
+    return os_mle->slrt;
 }
 
 extern void map_txt_mem_regions(void);

--- a/xen/arch/x86/include/asm/processor.h
+++ b/xen/arch/x86/include/asm/processor.h
@@ -645,6 +645,7 @@ void set_in_mcu_opt_ctrl(uint32_t mask, uint32_t val);
 enum ap_boot_method {
     AP_BOOT_NORMAL,
     AP_BOOT_SKINIT,
+    AP_BOOT_TXT,
 };
 extern enum ap_boot_method ap_boot_method;
 

--- a/xen/arch/x86/include/asm/slaunch.h
+++ b/xen/arch/x86/include/asm/slaunch.h
@@ -11,6 +11,8 @@
 /*
  * Secure Launch event log entry types. The TXT specification defines the
  * base event value as 0x400 for DRTM values.
+ *
+ * Using the same values for AMD SKINIT.
  */
 #define TXT_EVTYPE_BASE            0x400
 #define DLE_EVTYPE_SLAUNCH         (TXT_EVTYPE_BASE + 0x102)

--- a/xen/arch/x86/include/asm/slaunch.h
+++ b/xen/arch/x86/include/asm/slaunch.h
@@ -1,0 +1,65 @@
+#ifndef _ASM_X86_SLAUNCH_H_
+#define _ASM_X86_SLAUNCH_H_
+
+#include <xen/types.h>
+#include <xen/multiboot.h>
+#include <xen/slr_table.h>
+
+#define DRTM_LOC                   2
+#define DRTM_CODE_PCR              17
+#define DRTM_DATA_PCR              18
+
+/*
+ * Secure Launch event log entry types. The TXT specification defines the
+ * base event value as 0x400 for DRTM values.
+ */
+#define TXT_EVTYPE_BASE            0x400
+#define DLE_EVTYPE_SLAUNCH         (TXT_EVTYPE_BASE + 0x102)
+#define DLE_EVTYPE_SLAUNCH_START   (TXT_EVTYPE_BASE + 0x103)
+#define DLE_EVTYPE_SLAUNCH_END     (TXT_EVTYPE_BASE + 0x104)
+
+extern bool slaunch_active;
+
+/* evt_log is a physical address and the caller must map it to virtual, if
+ * needed. */
+static inline void find_evt_log(struct slr_table *slrt, void **evt_log,
+                                uint32_t *evt_log_size)
+{
+    struct slr_entry_log_info *log_info =
+        (void *)slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
+
+    if ( log_info != NULL ) {
+        *evt_log = _p(log_info->addr);
+        *evt_log_size = log_info->size;
+    } else {
+        *evt_log = NULL;
+        *evt_log_size = 0;
+    }
+}
+
+/*
+ * This helper function is used to map memory using L2 page tables by aligning
+ * mapped regions to 2MB. This way page allocator (which at this point isn't
+ * yet initialized) isn't needed for creating new L1 mappings. The function
+ * also checks and skips memory already mapped by the prebuilt tables.
+ *
+ * There is no unmap_l2() because the function is meant to be used for code that
+ * accesses TXT registers and TXT heap soon after which Xen rebuilds memory
+ * maps, effectively dropping all existing mappings.
+ */
+extern int map_l2(unsigned long paddr, unsigned long size);
+
+void tpm_hash_extend(unsigned loc, unsigned pcr, uint8_t *buf, unsigned size,
+                     uint32_t type, uint8_t *log_data, unsigned log_data_size);
+
+/* Measures essential parts of SLR table before making use of them. */
+void tpm_measure_slrt(void);
+
+/* Takes measurements of DRTM policy entries except for MBI and SLRT which
+ * should have been measured by the time this is called. Also performs sanity
+ * checks of the policy and panics on failure. In particular, the function
+ * verifies that DRTM is consistent with MultibootInfo (MBI) (the MBI address
+ * is assumed to be virtual). */
+void tpm_process_drtm_policy(const multiboot_info_t *mbi);
+
+#endif /* _ASM_X86_SLAUNCH_H_ */

--- a/xen/arch/x86/include/asm/slaunch.h
+++ b/xen/arch/x86/include/asm/slaunch.h
@@ -18,6 +18,7 @@
 #define DLE_EVTYPE_SLAUNCH_END     (TXT_EVTYPE_BASE + 0x104)
 
 extern bool slaunch_active;
+extern uint32_t slaunch_slrt; /* physical address */
 
 /* evt_log is a physical address and the caller must map it to virtual, if
  * needed. */

--- a/xen/arch/x86/include/asm/slaunch.h
+++ b/xen/arch/x86/include/asm/slaunch.h
@@ -2,7 +2,6 @@
 #define _ASM_X86_SLAUNCH_H_
 
 #include <xen/types.h>
-#include <xen/multiboot.h>
 #include <xen/slr_table.h>
 
 #define DRTM_LOC                   2
@@ -48,18 +47,5 @@ static inline void find_evt_log(struct slr_table *slrt, void **evt_log,
  * maps, effectively dropping all existing mappings.
  */
 extern int map_l2(unsigned long paddr, unsigned long size);
-
-void tpm_hash_extend(unsigned loc, unsigned pcr, uint8_t *buf, unsigned size,
-                     uint32_t type, uint8_t *log_data, unsigned log_data_size);
-
-/* Measures essential parts of SLR table before making use of them. */
-void tpm_measure_slrt(void);
-
-/* Takes measurements of DRTM policy entries except for MBI and SLRT which
- * should have been measured by the time this is called. Also performs sanity
- * checks of the policy and panics on failure. In particular, the function
- * verifies that DRTM is consistent with MultibootInfo (MBI) (the MBI address
- * is assumed to be virtual). */
-void tpm_process_drtm_policy(const multiboot_info_t *mbi);
 
 #endif /* _ASM_X86_SLAUNCH_H_ */

--- a/xen/arch/x86/include/asm/slaunch.h
+++ b/xen/arch/x86/include/asm/slaunch.h
@@ -54,6 +54,10 @@ static inline void find_evt_log(struct slr_table *slrt, void **evt_log,
     }
 }
 
+void map_slaunch_mem_regions(void);
+
+void protect_slaunch_mem_regions(void);
+
 /*
  * This helper function is used to map memory using L2 page tables by aligning
  * mapped regions to 2MB. This way page allocator (which at this point isn't

--- a/xen/arch/x86/include/asm/slaunch.h
+++ b/xen/arch/x86/include/asm/slaunch.h
@@ -17,6 +17,23 @@
 #define DLE_EVTYPE_SLAUNCH_START   (TXT_EVTYPE_BASE + 0x103)
 #define DLE_EVTYPE_SLAUNCH_END     (TXT_EVTYPE_BASE + 0x104)
 
+#ifndef cpuid
+/*
+ * Generic CPUID function
+ * clear %ecx since some cpus (Cyrix MII) do not set or clear %ecx
+ * resulting in stale register contents being returned.
+ *
+ * Copied from processor.h because that header can't be included by early code.
+ */
+#define cpuid(_op,_eax,_ebx,_ecx,_edx)          \
+    asm volatile ( "cpuid"                      \
+          : "=a" (*(int *)(_eax)),              \
+            "=b" (*(int *)(_ebx)),              \
+            "=c" (*(int *)(_ecx)),              \
+            "=d" (*(int *)(_edx))               \
+          : "0" (_op), "2" (0) )
+#endif
+
 extern bool slaunch_active;
 extern uint32_t slaunch_slrt; /* physical address */
 

--- a/xen/arch/x86/include/asm/tpm.h
+++ b/xen/arch/x86/include/asm/tpm.h
@@ -1,0 +1,23 @@
+#ifndef _ASM_X86_TPM_H_
+#define _ASM_X86_TPM_H_
+
+#include <xen/types.h>
+#include <xen/multiboot.h>
+
+#define TPM_TIS_BASE  0xFED40000
+#define TPM_TIS_SIZE  0x00010000
+
+void tpm_hash_extend(unsigned loc, unsigned pcr, uint8_t *buf, unsigned size,
+                     uint32_t type, uint8_t *log_data, unsigned log_data_size);
+
+/* Measures essential parts of SLR table before making use of them. */
+void tpm_measure_slrt(void);
+
+/* Takes measurements of DRTM policy entries except for MBI and SLRT which
+ * should have been measured by the time this is called. Also performs sanity
+ * checks of the policy and panics on failure. In particular, the function
+ * verifies that DRTM is consistent with MultibootInfo (MBI) (the MBI address
+ * is assumed to be virtual). */
+void tpm_process_drtm_policy(const multiboot_info_t *mbi);
+
+#endif /* _ASM_X86_TPM_H_ */

--- a/xen/arch/x86/intel_txt.c
+++ b/xen/arch/x86/intel_txt.c
@@ -6,6 +6,7 @@
 #include <asm/page.h>
 #include <asm/intel_txt.h>
 #include <asm/slaunch.h>
+#include <asm/tpm.h>
 #include <xen/init.h>
 #include <xen/mm.h>
 #include <xen/slr_table.h>
@@ -18,6 +19,7 @@ void __init map_txt_mem_regions(void)
     uint32_t evt_log_size;
 
     map_l2(TXT_PRIV_CONFIG_REGS_BASE, NR_TXT_CONFIG_PAGES * PAGE_SIZE);
+    map_l2(TPM_TIS_BASE, TPM_TIS_SIZE);
 
     txt_heap_base = read_txt_reg(TXTCR_HEAP_BASE);
     BUG_ON(txt_heap_base == 0);

--- a/xen/arch/x86/intel_txt.c
+++ b/xen/arch/x86/intel_txt.c
@@ -5,37 +5,12 @@
 #include <xen/string.h>
 #include <asm/page.h>
 #include <asm/intel_txt.h>
+#include <asm/slaunch.h>
 #include <xen/init.h>
 #include <xen/mm.h>
 #include <xen/slr_table.h>
 
 static uint64_t __initdata txt_heap_base, txt_heap_size;
-
-bool __initdata slaunch_active;
-
-static void __maybe_unused compile_time_checks(void)
-{
-    BUILD_BUG_ON(sizeof(slaunch_active) != 1);
-}
-
-int __init map_l2(unsigned long paddr, unsigned long size)
-{
-    unsigned long aligned_paddr = paddr & ~((1ULL << L2_PAGETABLE_SHIFT) - 1);
-    unsigned long pages = ((paddr + size) - aligned_paddr);
-    pages = ROUNDUP(pages, 1ULL << L2_PAGETABLE_SHIFT) >> PAGE_SHIFT;
-
-    if ( (aligned_paddr + pages * PAGE_SIZE) <= PREBUILT_MAP_LIMIT )
-        return 0;
-
-    if ( aligned_paddr < PREBUILT_MAP_LIMIT ) {
-        pages -= (PREBUILT_MAP_LIMIT - aligned_paddr) >> PAGE_SHIFT;
-        aligned_paddr = PREBUILT_MAP_LIMIT;
-    }
-
-    return map_pages_to_xen((unsigned long)__va(aligned_paddr),
-                            maddr_to_mfn(aligned_paddr),
-                            pages, PAGE_HYPERVISOR);
-}
 
 void __init map_txt_mem_regions(void)
 {

--- a/xen/arch/x86/intel_txt.c
+++ b/xen/arch/x86/intel_txt.c
@@ -15,11 +15,7 @@ static uint64_t __initdata txt_heap_base, txt_heap_size;
 
 void __init map_txt_mem_regions(void)
 {
-    void *evt_log_addr;
-    uint32_t evt_log_size;
-
     map_l2(TXT_PRIV_CONFIG_REGS_BASE, NR_TXT_CONFIG_PAGES * PAGE_SIZE);
-    map_l2(TPM_TIS_BASE, TPM_TIS_SIZE);
 
     txt_heap_base = read_txt_reg(TXTCR_HEAP_BASE);
     BUG_ON(txt_heap_base == 0);
@@ -28,16 +24,10 @@ void __init map_txt_mem_regions(void)
     BUG_ON(txt_heap_size == 0);
 
     map_l2(txt_heap_base, txt_heap_size);
-
-    find_evt_log(__va(slaunch_slrt), &evt_log_addr, &evt_log_size);
-    map_l2((unsigned long)evt_log_addr, evt_log_size);
 }
 
 void __init protect_txt_mem_regions(void)
 {
-    void *evt_log_addr;
-    uint32_t evt_log_size;
-
     uint64_t sinit_base, sinit_size;
 
     /* TXT Heap */
@@ -47,17 +37,6 @@ void __init protect_txt_mem_regions(void)
     e820_change_range_type(&e820_raw, txt_heap_base,
                            txt_heap_base + txt_heap_size,
                            E820_RAM, E820_RESERVED);
-
-    /* TXT TPM Event Log */
-    find_evt_log(__va(slaunch_slrt), &evt_log_addr, &evt_log_size);
-    if ( evt_log_addr != 0 ) {
-        printk("SLAUNCH: reserving event log (%#lx - %#lx)\n",
-               (uint64_t)evt_log_addr,
-               (uint64_t)evt_log_addr + evt_log_size);
-        e820_change_range_type(&e820_raw, (uint64_t)evt_log_addr,
-                               (uint64_t)evt_log_addr + evt_log_size,
-                               E820_RAM, E820_RESERVED);
-    }
 
     sinit_base = read_txt_reg(TXTCR_SINIT_BASE);
     BUG_ON(sinit_base == 0);

--- a/xen/arch/x86/intel_txt.c
+++ b/xen/arch/x86/intel_txt.c
@@ -52,7 +52,7 @@ void __init map_txt_mem_regions(void)
 
     map_l2(txt_heap_base, txt_heap_size);
 
-    find_evt_log(&evt_log_addr, &evt_log_size);
+    find_evt_log(__va(txt_find_slrt()), &evt_log_addr, &evt_log_size);
     map_l2((unsigned long)evt_log_addr, evt_log_size);
 }
 
@@ -72,7 +72,7 @@ void __init protect_txt_mem_regions(void)
                            E820_RAM, E820_RESERVED);
 
     /* TXT TPM Event Log */
-    find_evt_log(&evt_log_addr, &evt_log_size);
+    find_evt_log(__va(txt_find_slrt()), &evt_log_addr, &evt_log_size);
     if ( evt_log_addr != 0 ) {
         printk("SLAUNCH: reserving event log (%#lx - %#lx)\n",
                (uint64_t)evt_log_addr,

--- a/xen/arch/x86/intel_txt.c
+++ b/xen/arch/x86/intel_txt.c
@@ -29,7 +29,7 @@ void __init map_txt_mem_regions(void)
 
     map_l2(txt_heap_base, txt_heap_size);
 
-    find_evt_log(__va(txt_find_slrt()), &evt_log_addr, &evt_log_size);
+    find_evt_log(__va(slaunch_slrt), &evt_log_addr, &evt_log_size);
     map_l2((unsigned long)evt_log_addr, evt_log_size);
 }
 
@@ -49,7 +49,7 @@ void __init protect_txt_mem_regions(void)
                            E820_RAM, E820_RESERVED);
 
     /* TXT TPM Event Log */
-    find_evt_log(__va(txt_find_slrt()), &evt_log_addr, &evt_log_size);
+    find_evt_log(__va(slaunch_slrt), &evt_log_addr, &evt_log_size);
     if ( evt_log_addr != 0 ) {
         printk("SLAUNCH: reserving event log (%#lx - %#lx)\n",
                (uint64_t)evt_log_addr,

--- a/xen/arch/x86/setup.c
+++ b/xen/arch/x86/setup.c
@@ -56,6 +56,7 @@
 #include <asm/microcode.h>
 #include <asm/pv/domain.h>
 #include <asm/intel_txt.h>
+#include <asm/slaunch.h>
 
 /* opt_nosmp: If true, secondary processors are ignored. */
 static bool __initdata opt_nosmp;

--- a/xen/arch/x86/setup.c
+++ b/xen/arch/x86/setup.c
@@ -55,7 +55,6 @@
 #include <asm/guest.h>
 #include <asm/microcode.h>
 #include <asm/pv/domain.h>
-#include <asm/intel_txt.h>
 #include <asm/slaunch.h>
 #include <asm/tpm.h>
 
@@ -1172,13 +1171,15 @@ void __init noreturn __start_xen(unsigned long mbi_p)
 
     if ( slaunch_active )
     {
-        /* Prepare for TXT-related code. */
-        map_txt_mem_regions();
+        /* Prepare for accesses to essential data structures setup by boot
+         * environment. */
+        map_slaunch_mem_regions();
+
         /* Measure SLRT here because it gets used by init_e820(), the rest is
          * measured below by tpm_process_drtm_policy(). */
         tpm_measure_slrt();
-        /* Reserve TXT heap and SINIT. */
-        protect_txt_mem_regions();
+
+        protect_slaunch_mem_regions();
     }
 
     /* Sanitise the raw E820 map to produce a final clean version. */

--- a/xen/arch/x86/setup.c
+++ b/xen/arch/x86/setup.c
@@ -57,6 +57,7 @@
 #include <asm/pv/domain.h>
 #include <asm/intel_txt.h>
 #include <asm/slaunch.h>
+#include <asm/tpm.h>
 
 /* opt_nosmp: If true, secondary processors are ignored. */
 static bool __initdata opt_nosmp;

--- a/xen/arch/x86/slaunch.c
+++ b/xen/arch/x86/slaunch.c
@@ -1,0 +1,238 @@
+#include <xen/types.h>
+#include <asm/intel_txt.h>
+#include <asm/page.h>
+#include <asm/processor.h>
+#include <asm/slaunch.h>
+#include <xen/init.h>
+#include <xen/mm.h>
+#include <xen/multiboot.h>
+
+bool __initdata slaunch_active;
+
+static void __maybe_unused compile_time_checks(void)
+{
+    BUILD_BUG_ON(sizeof(slaunch_active) != 1);
+}
+
+int __init map_l2(unsigned long paddr, unsigned long size)
+{
+    unsigned long aligned_paddr = paddr & ~((1ULL << L2_PAGETABLE_SHIFT) - 1);
+    unsigned long pages = ((paddr + size) - aligned_paddr);
+    pages = ROUNDUP(pages, 1ULL << L2_PAGETABLE_SHIFT) >> PAGE_SHIFT;
+
+    if ( (aligned_paddr + pages * PAGE_SIZE) <= PREBUILT_MAP_LIMIT )
+        return 0;
+
+    if ( aligned_paddr < PREBUILT_MAP_LIMIT )
+    {
+        pages -= (PREBUILT_MAP_LIMIT - aligned_paddr) >> PAGE_SHIFT;
+        aligned_paddr = PREBUILT_MAP_LIMIT;
+    }
+
+    return map_pages_to_xen((unsigned long)__va(aligned_paddr),
+                            maddr_to_mfn(aligned_paddr),
+                            pages, PAGE_HYPERVISOR);
+}
+
+static struct slr_table *slr_get_table(void)
+{
+    uint32_t slrt_pa = txt_find_slrt();
+    struct slr_table *slrt = __va(slrt_pa);
+
+    map_l2(slrt_pa, PAGE_SIZE);
+
+    if ( slrt->magic != SLR_TABLE_MAGIC )
+        panic("SLRT has invalid magic value: %#08x!\n", slrt->magic);
+    /* XXX: are newer revisions allowed? */
+    if ( slrt->revision != SLR_TABLE_REVISION )
+        panic("SLRT is of unsupported revision: %#04x!\n", slrt->revision);
+    if ( slrt->architecture != SLR_INTEL_TXT )
+        panic("SLRT is for unexpected architecture: %#04x!\n",
+              slrt->architecture);
+    if ( slrt->size > slrt->max_size )
+        panic("SLRT is larger than its max size: %#08x > %#08x!\n",
+              slrt->size, slrt->max_size);
+
+    if ( slrt->size > PAGE_SIZE )
+        map_l2(slrt_pa, slrt->size);
+
+    return slrt;
+}
+
+void tpm_measure_slrt(void)
+{
+    struct slr_table *slrt = slr_get_table();
+
+    if ( slrt->revision == 1 )
+    {
+        /* In revision one of the SLRT, only Intel info table is measured. */
+        struct slr_entry_intel_info *intel_info =
+            (void *)slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_INTEL_INFO);
+        if ( intel_info == NULL )
+            panic("SLRT is missing Intel-specific information!\n");
+
+        tpm_hash_extend(DRTM_LOC, DRTM_DATA_PCR, (uint8_t *)intel_info,
+                        sizeof(*intel_info), DLE_EVTYPE_SLAUNCH, NULL, 0);
+    }
+    else
+    {
+        /*
+         * slr_get_table() checks that the revision is valid, so we must not
+         * get here unless the code is wrong.
+         */
+        panic("Unhandled SLRT revision: %d!\n", slrt->revision);
+    }
+}
+
+static struct slr_entry_policy *slr_get_policy(struct slr_table *slrt)
+{
+    struct slr_entry_policy *policy;
+
+    policy = (struct slr_entry_policy *)
+        slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_DRTM_POLICY);
+    if (policy == NULL)
+        panic("SLRT is missing DRTM policy!\n");
+
+    /* XXX: are newer revisions allowed? */
+    if ( policy->revision != SLR_POLICY_REVISION )
+        panic("DRTM policy in SLRT is of unsupported revision: %#04x!\n",
+              slrt->revision);
+
+    return policy;
+}
+
+static void check_drtm_policy(struct slr_table *slrt,
+                              struct slr_entry_policy *policy,
+                              struct slr_policy_entry *policy_entry,
+                              const multiboot_info_t *mbi)
+{
+    uint32_t i;
+    module_t *mods;
+    uint32_t num_mod_entries;
+
+    if ( policy->nr_entries < 2 )
+        panic("DRTM policy in SLRT contains less than 2 entries (%d)!\n",
+              policy->nr_entries);
+
+    /* MBI policy entry must be the first one, so that measuring order matches
+     * policy order. */
+    if ( policy_entry[0].entity_type != SLR_ET_MULTIBOOT2_INFO )
+        panic("First entry of DRTM policy in SLRT is not MBI: %#04x!\n",
+              policy_entry[0].entity_type);
+    if ( policy_entry[0].pcr != DRTM_DATA_PCR )
+        panic("MBI was measured to %d instead of %d PCR!\n", DRTM_DATA_PCR,
+              policy_entry[0].pcr);
+
+    /* SLRT policy entry must be the second one. */
+    if ( policy_entry[1].entity_type != SLR_ET_SLRT )
+        panic("Second entry of DRTM policy in SLRT is not SLRT: %#04x!\n",
+              policy_entry[1].entity_type);
+    if ( policy_entry[1].pcr != DRTM_DATA_PCR )
+        panic("SLRT was measured to %d instead of %d PCR!\n", DRTM_DATA_PCR,
+              policy_entry[1].pcr);
+    if ( policy_entry[1].entity != (uint64_t)__pa(slrt) )
+        panic("SLRT address (%#08lx) differes from its DRTM entry (%#08lx)\n",
+              __pa(slrt), policy_entry[1].entity);
+
+    mods = __va(mbi->mods_addr);
+    for ( i = 0; i < mbi->mods_count; i++ )
+    {
+        uint16_t j;
+        uint64_t start = mods[i].mod_start;
+        uint64_t size = mods[i].mod_end - mods[i].mod_start;
+
+        for ( j = 0; j < policy->nr_entries; j++ )
+        {
+            if ( policy_entry[j].entity_type != SLR_ET_MULTIBOOT2_MODULE )
+                continue;
+
+            if ( policy_entry[j].entity == start &&
+                 policy_entry[j].size == size )
+                break;
+        }
+
+        if ( j >= policy->nr_entries )
+        {
+            panic("Couldn't find Multiboot module \"%s\" (at %d) in DRTM of Secure Launch\n",
+                  (const char *)__va(mods[i].string), i);
+        }
+    }
+
+    num_mod_entries = 0;
+    for ( i = 0; i < policy->nr_entries; i++ )
+    {
+        if ( policy_entry[i].entity_type == SLR_ET_MULTIBOOT2_MODULE )
+            num_mod_entries++;
+    }
+
+    if ( mbi->mods_count != num_mod_entries )
+    {
+        panic("Unexpected number of Multiboot modules: %d instead of %d\n",
+              (int)mbi->mods_count, (int)num_mod_entries);
+    }
+}
+
+void tpm_process_drtm_policy(const multiboot_info_t *mbi)
+{
+    struct slr_table *slrt;
+    struct slr_entry_policy *policy;
+    struct slr_policy_entry *policy_entry;
+    uint16_t i;
+
+    slrt = slr_get_table();
+
+    policy = slr_get_policy(slrt);
+    policy_entry = (struct slr_policy_entry *)
+        ((uint8_t *)policy + sizeof(*policy));
+
+    check_drtm_policy(slrt, policy, policy_entry, mbi);
+    /* MBI was measured in tpm_extend_mbi(). */
+    policy_entry[0].flags |= SLR_POLICY_FLAG_MEASURED;
+    /* SLRT was measured in tpm_measure_slrt(). */
+    policy_entry[1].flags |= SLR_POLICY_FLAG_MEASURED;
+
+    for ( i = 2; i < policy->nr_entries; i++ )
+    {
+        uint64_t start = policy_entry[i].entity;
+        uint64_t size = policy_entry[i].size;
+
+        /* No already measured entries are expected here. */
+        if ( policy_entry[i].flags & SLR_POLICY_FLAG_MEASURED )
+            panic("DRTM entry at %d was measured out of order!\n", i);
+
+        switch ( policy_entry[i].entity_type )
+        {
+        case SLR_ET_MULTIBOOT2_INFO:
+            panic("Duplicated MBI entry in DRTM of Secure Launch at %d\n", i);
+        case SLR_ET_SLRT:
+            panic("Duplicated SLRT entry in DRTM of Secure Launch at %d\n", i);
+
+        case SLR_ET_UNSPECIFIED:
+        case SLR_ET_BOOT_PARAMS:
+        case SLR_ET_SETUP_DATA:
+        case SLR_ET_CMDLINE:
+        case SLR_ET_UEFI_MEMMAP:
+        case SLR_ET_RAMDISK:
+        case SLR_ET_MULTIBOOT2_MODULE:
+        case SLR_ET_TXT_OS2MLE:
+            /* Measure this entry below. */
+            break;
+
+        case SLR_ET_UNUSED:
+            /* Skip this entry. */
+            continue;
+        }
+
+        if ( policy_entry[i].flags & SLR_POLICY_IMPLICIT_SIZE )
+            panic("Unexpected implicitly-sized DRTM entry of Secure Launch at %d\n",
+                  i);
+
+        map_l2(start, size);
+        tpm_hash_extend(DRTM_LOC, policy_entry[i].pcr, __va(start), size,
+                        DLE_EVTYPE_SLAUNCH, (uint8_t *)policy_entry[i].evt_info,
+                        strnlen(policy_entry[i].evt_info,
+                                TPM_EVENT_INFO_LENGTH));
+
+        policy_entry[i].flags |= SLR_POLICY_FLAG_MEASURED;
+    }
+}

--- a/xen/arch/x86/slaunch.c
+++ b/xen/arch/x86/slaunch.c
@@ -1,5 +1,4 @@
 #include <xen/types.h>
-#include <asm/intel_txt.h>
 #include <asm/page.h>
 #include <asm/processor.h>
 #include <asm/slaunch.h>
@@ -9,6 +8,7 @@
 #include <xen/multiboot.h>
 
 bool __initdata slaunch_active;
+uint32_t __initdata slaunch_slrt;
 
 static void __maybe_unused compile_time_checks(void)
 {
@@ -37,10 +37,9 @@ int __init map_l2(unsigned long paddr, unsigned long size)
 
 static struct slr_table *slr_get_table(void)
 {
-    uint32_t slrt_pa = txt_find_slrt();
-    struct slr_table *slrt = __va(slrt_pa);
+    struct slr_table *slrt = __va(slaunch_slrt);
 
-    map_l2(slrt_pa, PAGE_SIZE);
+    map_l2(slaunch_slrt, PAGE_SIZE);
 
     if ( slrt->magic != SLR_TABLE_MAGIC )
         panic("SLRT has invalid magic value: %#08x!\n", slrt->magic);
@@ -55,7 +54,7 @@ static struct slr_table *slr_get_table(void)
               slrt->size, slrt->max_size);
 
     if ( slrt->size > PAGE_SIZE )
-        map_l2(slrt_pa, slrt->size);
+        map_l2(slaunch_slrt, slrt->size);
 
     return slrt;
 }

--- a/xen/arch/x86/slaunch.c
+++ b/xen/arch/x86/slaunch.c
@@ -3,6 +3,7 @@
 #include <asm/page.h>
 #include <asm/processor.h>
 #include <asm/slaunch.h>
+#include <asm/tpm.h>
 #include <xen/init.h>
 #include <xen/mm.h>
 #include <xen/multiboot.h>

--- a/xen/arch/x86/smpboot.c
+++ b/xen/arch/x86/smpboot.c
@@ -432,7 +432,7 @@ void start_secondary(unsigned int cpu)
     startup_cpu_idle_loop();
 }
 
-static int slaunch_wake_aps(unsigned long trampoline_rm)
+static int wake_aps_in_txt(unsigned long trampoline_rm)
 {
     struct txt_sinit_mle_data *sinit_mle =
               txt_sinit_mle_data_start(__va(read_txt_reg(TXTCR_HEAP_BASE)));
@@ -482,8 +482,8 @@ static int wakeup_secondary_cpu(int phys_apicid, unsigned long start_eip)
     if ( tboot_in_measured_env() && !tboot_wake_ap(phys_apicid, start_eip) )
         return 0;
 
-    if ( slaunch_active )
-        return slaunch_wake_aps(start_eip);
+    if ( ap_boot_method == AP_BOOT_TXT )
+        return wake_aps_in_txt(start_eip);
 
     /*
      * Use destination shorthand for broadcasting IPIs during boot.

--- a/xen/arch/x86/tpm.c
+++ b/xen/arch/x86/tpm.c
@@ -36,6 +36,8 @@ asm (
 #endif
 #define __va(x)     _p(x)
 
+uint32_t slaunch_slrt;
+
 /*
  * The implementation is necessary if compiler chooses to not use an inline
  * builtin.
@@ -926,9 +928,7 @@ void tpm_hash_extend(unsigned loc, unsigned pcr, uint8_t *buf, unsigned size,
     void *evt_log_addr;
     uint32_t evt_log_size;
 
-    struct slr_table *slrt = __va(txt_find_slrt());
-
-    find_evt_log(slrt, &evt_log_addr, &evt_log_size);
+    find_evt_log(__va(slaunch_slrt), &evt_log_addr, &evt_log_size);
     evt_log_addr = __va(evt_log_addr);
 
     if ( is_tpm12() ) {
@@ -962,8 +962,12 @@ void tpm_hash_extend(unsigned loc, unsigned pcr, uint8_t *buf, unsigned size,
 }
 
 #ifdef __EARLY_TPM__
-void __stdcall tpm_extend_mbi(uint32_t *mbi)
+void __stdcall tpm_extend_mbi(uint32_t *mbi, uint32_t slrt_pa)
 {
+    /* Early TPM code isn't linked with the rest but still needs to have this
+     * variable with correct value. */
+    slaunch_slrt = slrt_pa;
+
     /* MBI starts with uint32_t total_size. */
     tpm_hash_extend(DRTM_LOC, DRTM_DATA_PCR, (uint8_t *)mbi, *mbi,
                     DLE_EVTYPE_SLAUNCH, NULL, 0);

--- a/xen/arch/x86/tpm.c
+++ b/xen/arch/x86/tpm.c
@@ -30,6 +30,7 @@ asm (
 #include "boot/defs.h"
 #include "include/asm/intel_txt.h"
 #include "include/asm/slaunch.h"
+#include "include/asm/tpm.h"
 #ifdef __va
 #error "__va defined in non-paged mode!"
 #endif
@@ -66,13 +67,13 @@ void *memcpy(void *dest, const void *src, size_t n)
 #include <xen/types.h>
 #include <asm/intel_txt.h>
 #include <asm/slaunch.h>
+#include <asm/tpm.h>
 
 #endif  /* __EARLY_TPM__ */
 
 #include <xen/sha1.h>
 #include <xen/sha256.h>
 
-#define TPM_TIS_BASE            0xFED40000
 #define TPM_LOC_REG(loc, reg)   (0x1000 * (loc) + (reg))
 
 #define TPM_ACCESS_(x)          TPM_LOC_REG(x, 0x00)

--- a/xen/arch/x86/tpm.c
+++ b/xen/arch/x86/tpm.c
@@ -29,6 +29,7 @@ asm (
 
 #include "boot/defs.h"
 #include "include/asm/intel_txt.h"
+#include "include/asm/slaunch.h"
 #ifdef __va
 #error "__va defined in non-paged mode!"
 #endif
@@ -64,6 +65,7 @@ void *memcpy(void *dest, const void *src, size_t n)
 #include <xen/pfn.h>
 #include <xen/types.h>
 #include <asm/intel_txt.h>
+#include <asm/slaunch.h>
 
 #endif  /* __EARLY_TPM__ */
 
@@ -963,199 +965,6 @@ void __stdcall tpm_extend_mbi(uint32_t *mbi)
 {
     /* MBI starts with uint32_t total_size. */
     tpm_hash_extend(DRTM_LOC, DRTM_DATA_PCR, (uint8_t *)mbi, *mbi,
-                    TXT_EVTYPE_SLAUNCH, NULL, 0);
-}
-#else
-static struct slr_table *slr_get_table(void)
-{
-    uint32_t slrt_pa = txt_find_slrt();
-    struct slr_table *slrt = __va(slrt_pa);
-
-    map_l2(slrt_pa, PAGE_SIZE);
-
-    if ( slrt->magic != SLR_TABLE_MAGIC )
-        panic("SLRT has invalid magic value: %#08x!\n", slrt->magic);
-    /* XXX: are newer revisions allowed? */
-    if ( slrt->revision != SLR_TABLE_REVISION )
-        panic("SLRT is of unsupported revision: %#04x!\n", slrt->revision);
-    if ( slrt->architecture != SLR_INTEL_TXT )
-        panic("SLRT is for unexpected architecture: %#04x!\n",
-              slrt->architecture);
-    if ( slrt->size > slrt->max_size )
-        panic("SLRT is larger than its max size: %#08x > %#08x!\n",
-              slrt->size, slrt->max_size);
-
-    if ( slrt->size > PAGE_SIZE )
-        map_l2(slrt_pa, slrt->size);
-
-    return slrt;
-}
-
-void tpm_measure_slrt(void)
-{
-    struct slr_table *slrt = slr_get_table();
-
-    if ( slrt->revision == 1 ) {
-        /* In revision one of the SLRT, only Intel info table is measured. */
-        struct slr_entry_intel_info *intel_info =
-            (void *)slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_INTEL_INFO);
-        if ( intel_info == NULL )
-            panic("SLRT is missing Intel-specific information!\n");
-
-        tpm_hash_extend(DRTM_LOC, DRTM_DATA_PCR, (uint8_t *)intel_info,
-                        sizeof(*intel_info), TXT_EVTYPE_SLAUNCH, NULL, 0);
-    } else {
-        /*
-         * slr_get_table() checks that the revision is valid, so we must not
-         * get here unless the code is wrong.
-         */
-        panic("Unhandled SLRT revision: %d!\n", slrt->revision);
-    }
-}
-
-static struct slr_entry_policy *slr_get_policy(struct slr_table *slrt)
-{
-    struct slr_entry_policy *policy;
-
-    policy = (struct slr_entry_policy *)
-        slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_DRTM_POLICY);
-    if (policy == NULL)
-        panic("SLRT is missing DRTM policy!\n");
-
-    /* XXX: are newer revisions allowed? */
-    if ( policy->revision != SLR_POLICY_REVISION )
-        panic("DRTM policy in SLRT is of unsupported revision: %#04x!\n",
-              slrt->revision);
-
-    return policy;
-}
-
-static void check_drtm_policy(struct slr_table *slrt,
-                              struct slr_entry_policy *policy,
-                              struct slr_policy_entry *policy_entry,
-                              const multiboot_info_t *mbi)
-{
-    uint32_t i;
-    module_t *mods;
-    uint32_t num_mod_entries;
-
-    if ( policy->nr_entries < 2 )
-        panic("DRTM policy in SLRT contains less than 2 entries (%d)!\n",
-              policy->nr_entries);
-
-    /* MBI policy entry must be the first one, so that measuring order matches
-     * policy order. */
-    if ( policy_entry[0].entity_type != SLR_ET_MULTIBOOT2_INFO )
-        panic("First entry of DRTM policy in SLRT is not MBI: %#04x!\n",
-              policy_entry[0].entity_type);
-    if ( policy_entry[0].pcr != DRTM_DATA_PCR )
-        panic("MBI was measured to %d instead of %d PCR!\n", DRTM_DATA_PCR,
-              policy_entry[0].pcr);
-
-    /* SLRT policy entry must be the second one. */
-    if ( policy_entry[1].entity_type != SLR_ET_SLRT )
-        panic("Second entry of DRTM policy in SLRT is not SLRT: %#04x!\n",
-              policy_entry[1].entity_type);
-    if ( policy_entry[1].pcr != DRTM_DATA_PCR )
-        panic("SLRT was measured to %d instead of %d PCR!\n", DRTM_DATA_PCR,
-              policy_entry[1].pcr);
-    if ( policy_entry[1].entity != (uint64_t)__pa(slrt) )
-        panic("SLRT address (%#08lx) differes from its DRTM entry (%#08lx)\n",
-              __pa(slrt), policy_entry[1].entity);
-
-    mods = __va(mbi->mods_addr);
-    for ( i = 0; i < mbi->mods_count; i++ ) {
-        uint16_t j;
-        uint64_t start = mods[i].mod_start;
-        uint64_t size = mods[i].mod_end - mods[i].mod_start;
-
-        for ( j = 0; j < policy->nr_entries; j++ ) {
-            if ( policy_entry[j].entity_type != SLR_ET_MULTIBOOT2_MODULE )
-                continue;
-
-            if ( policy_entry[j].entity == start &&
-                 policy_entry[j].size == size )
-                break;
-        }
-
-        if ( j >= policy->nr_entries ) {
-            panic("Couldn't find Multiboot module \"%s\" (at %d) in DRTM of Secure Launch\n",
-                  (const char *)__va(mods[i].string), i);
-        }
-    }
-
-    num_mod_entries = 0;
-    for ( i = 0; i < policy->nr_entries; i++ ) {
-        if ( policy_entry[i].entity_type == SLR_ET_MULTIBOOT2_MODULE )
-            num_mod_entries++;
-    }
-
-    if ( mbi->mods_count != num_mod_entries ) {
-        panic("Unexpected number of Multiboot modules: %d instead of %d\n",
-              (int)mbi->mods_count, (int)num_mod_entries);
-    }
-}
-
-void tpm_process_drtm_policy(const multiboot_info_t *mbi)
-{
-    struct slr_table *slrt;
-    struct slr_entry_policy *policy;
-    struct slr_policy_entry *policy_entry;
-    uint16_t i;
-
-    slrt = slr_get_table();
-
-    policy = slr_get_policy(slrt);
-    policy_entry = (struct slr_policy_entry *)
-        ((uint8_t *)policy + sizeof(*policy));
-
-    check_drtm_policy(slrt, policy, policy_entry, mbi);
-    /* MBI was measured in tpm_extend_mbi(). */
-    policy_entry[0].flags |= SLR_POLICY_FLAG_MEASURED;
-    /* SLRT was measured in tpm_measure_slrt(). */
-    policy_entry[1].flags |= SLR_POLICY_FLAG_MEASURED;
-
-    for ( i = 2; i < policy->nr_entries; i++ ) {
-        uint64_t start = policy_entry[i].entity;
-        uint64_t size = policy_entry[i].size;
-
-        /* No already measured entries are expected here. */
-        if ( policy_entry[i].flags & SLR_POLICY_FLAG_MEASURED )
-            panic("DRTM entry at %d was measured out of order!\n", i);
-
-        switch ( policy_entry[i].entity_type ) {
-        case SLR_ET_MULTIBOOT2_INFO:
-            panic("Duplicated MBI entry in DRTM of Secure Launch at %d\n", i);
-        case SLR_ET_SLRT:
-            panic("Duplicated SLRT entry in DRTM of Secure Launch at %d\n", i);
-
-        case SLR_ET_UNSPECIFIED:
-        case SLR_ET_BOOT_PARAMS:
-        case SLR_ET_SETUP_DATA:
-        case SLR_ET_CMDLINE:
-        case SLR_ET_UEFI_MEMMAP:
-        case SLR_ET_RAMDISK:
-        case SLR_ET_MULTIBOOT2_MODULE:
-        case SLR_ET_TXT_OS2MLE:
-            /* Measure this entry below. */
-            break;
-
-        case SLR_ET_UNUSED:
-            /* Skip this entry. */
-            continue;
-        }
-
-        if ( policy_entry[i].flags & SLR_POLICY_IMPLICIT_SIZE )
-            panic("Unexpected implicitly-sized DRTM entry of Secure Launch at %d\n",
-                  i);
-
-        map_l2(start, size);
-        tpm_hash_extend(DRTM_LOC, policy_entry[i].pcr, __va(start), size,
-                        TXT_EVTYPE_SLAUNCH, (uint8_t *)policy_entry[i].evt_info,
-                        strnlen(policy_entry[i].evt_info,
-                                TPM_EVENT_INFO_LENGTH));
-
-        policy_entry[i].flags |= SLR_POLICY_FLAG_MEASURED;
-    }
+                    DLE_EVTYPE_SLAUNCH, NULL, 0);
 }
 #endif


### PR DESCRIPTION
Moved some code into `slaunch.c` and `slaunch.h` to avoid putting AMD-specific things into files named `intel_txt.*` and stop putting too much into `tpm.c`.  Better to review by commits.

Also had to work around limitations of early TPM code for getting SLRT pointer and determining CPU vendor.