### PR TITLE
xen/arch/x86: fix TXT AP gate placement and MONITOR/MWAIT race

### DIFF
--- a/xen/arch/x86/boot/x86_64.S
+++ b/xen/arch/x86/boot/x86_64.S
@@ -30,7 +30,10 @@ ENTRY(__high_start)
         cmp     %esp, (%rcx, %rax, 4)
         jne     1b
 
-        /* %eax is now Xen CPU index. */
+        mov     %esp, %edx
+
+        /* %eax is now Xen CPU index, %edx is APIC ID. */
+
         lea     stack_base(%rip), %rcx
         mov     (%rcx, %rax, 8), %rsp
 
@@ -39,6 +42,25 @@ ENTRY(__high_start)
         hlt
 1:
         add     $(STACK_SIZE - CPUINFO_sizeof), %rsp
+
+        /*
+         * TXT AP gate.
+         *
+         * In TXT boot, SINIT releases all APs at once and they race into
+         * __high_start in parallel. We serialize APs initialization here
+         * to force them waking up in order expected by the BSP.
+         *
+         * The gate must be placed before STACK_CPUINFO_FIELD(cr4) is written
+         * below: for each AP, the BSP memsets that AP's cpu_info struct in
+         * cpu_smpboot_alloc() just before releasing it through the gate, so
+         * anything written earlier would be clobbered.
+         *
+         * In non-TXT boot, APs wake one-by-one via SIPI.
+         */
+        cmpl    $ASM_AP_BOOT_TXT, ap_boot_method(%rip)
+        jne     .L_after_stack_setup
+        mov     %edx, %edi
+        call    txt_ap_gate
 
 .L_after_stack_setup:
 

--- a/xen/arch/x86/smpboot.c
+++ b/xen/arch/x86/smpboot.c
@@ -255,9 +255,12 @@ void asmlinkage txt_ap_gate(int apicid)
 
     while ( txt_booting_apicid != apicid )
     {
-        asm volatile ( "monitor; xor %0,%0; mwait"
+        asm volatile ( "monitor"
                        :: "a"(__va(sinit_mle->rlp_wakeup_addr)), "c"(0),
                        "d"(0) : "memory" );
+        if ( txt_booting_apicid == apicid )
+            break;
+        asm volatile ( "mwait" :: "a"(0), "c"(0) );
     }
 }
 

--- a/xen/arch/x86/smpboot.c
+++ b/xen/arch/x86/smpboot.c
@@ -240,6 +240,27 @@ static void smp_callin(void)
         cpu_relax();
 }
 
+static int txt_booting_apicid;
+
+void asmlinkage txt_ap_gate(int apicid)
+{
+    uint64_t misc_enable;
+    const struct txt_sinit_mle_data *sinit_mle =
+          txt_start(__va(txt_read(TXTCR_HEAP_BASE)), TXT_SINIT2MLE);
+
+    /* TXT released us with MONITOR disabled in IA32_MISC_ENABLE. */
+    rdmsrl(MSR_IA32_MISC_ENABLE, misc_enable);
+    wrmsrl(MSR_IA32_MISC_ENABLE,
+           misc_enable | MSR_IA32_MISC_ENABLE_MONITOR_ENABLE);
+
+    while ( txt_booting_apicid != apicid )
+    {
+        asm volatile ( "monitor; xor %0,%0; mwait"
+                       :: "a"(__va(sinit_mle->rlp_wakeup_addr)), "c"(0),
+                       "d"(0) : "memory" );
+    }
+}
+
 /* CPUs for which sibling maps can be computed. */
 static cpumask_t cpu_sibling_setup_map;
 
@@ -332,29 +353,6 @@ void asmlinkage start_secondary(void)
     struct cpu_info *info = get_cpu_info();
     unsigned int cpu = smp_processor_id();
 
-    if ( ap_boot_method == AP_BOOT_TXT ) {
-        uint64_t misc_enable;
-        uint32_t my_apicid;
-        const struct txt_sinit_mle_data *sinit_mle =
-              txt_start(__va(txt_read(TXTCR_HEAP_BASE)), TXT_SINIT2MLE);
-
-        /* TXT released us with MONITOR disabled in IA32_MISC_ENABLE. */
-        rdmsrl(MSR_IA32_MISC_ENABLE, misc_enable);
-        wrmsrl(MSR_IA32_MISC_ENABLE,
-               misc_enable | MSR_IA32_MISC_ENABLE_MONITOR_ENABLE);
-
-        /* get_apic_id() reads from x2APIC if it thinks it is enabled. */
-        x2apic_ap_setup();
-        my_apicid = get_apic_id();
-
-        while ( my_apicid != x86_cpu_to_apicid[cpu] ) {
-            asm volatile ("monitor; xor %0,%0; mwait"
-                          :: "a"(__va(sinit_mle->rlp_wakeup_addr)), "c"(0),
-                          "d"(0) : "memory");
-            cpu = smp_processor_id();
-        }
-    }
-
     rdmsrl(MSR_EFER, this_cpu(efer));
 
     /*
@@ -441,7 +439,7 @@ void asmlinkage start_secondary(void)
     startup_cpu_idle_loop();
 }
 
-static int wake_aps_in_txt(void)
+static int wake_ap_in_txt(int phys_apicid)
 {
     const struct txt_sinit_mle_data *sinit_mle =
               txt_start(__va(txt_read(TXTCR_HEAP_BASE)), TXT_SINIT2MLE);
@@ -454,6 +452,8 @@ static int wake_aps_in_txt(void)
     join[3] = bootsym_phys(txt_ap_entry);   /* EIP */
 
     txt_write(TXTCR_MLE_JOIN, __pa(join));
+
+    txt_booting_apicid = phys_apicid;
 
     smp_mb();
 
@@ -485,7 +485,7 @@ static int wakeup_secondary_cpu(int phys_apicid, unsigned long start_eip)
         return 0;
 
     if ( ap_boot_method == AP_BOOT_TXT )
-        return wake_aps_in_txt();
+        return wake_ap_in_txt(phys_apicid);
 
     /*
      * Be paranoid about clearing APIC errors.

--- a/xen/arch/x86/x86_64/asm-offsets.c
+++ b/xen/arch/x86/x86_64/asm-offsets.c
@@ -245,4 +245,7 @@ void __dummy__(void)
     DEFINE(SL_EIR_size,     sizeof(struct slaunch_early_init_results));
     BLANK();
 #endif
+
+    DEFINE(ASM_AP_BOOT_TXT, AP_BOOT_TXT);
+    BLANK();
 }


### PR DESCRIPTION
Two fixes for the TXT AP gate needed after upstream changes:
1. Gate TXT AP startup earlier: the gate must be before the cpu_info.cr4 write in early assembly.
2. Fix potential deadlock in MONITOR/MWAIT TXT AP gate loop.

Tested by booting Trenchboot-XEN on Asus LCL laptop ([aem-staging-2026-03-13-accek branch](https://github.com/accek-itl/xen/tree/aem-staging-2026-03-13-accek) which included these commits) and verifying PCRs 17, 18 are non-zero.

Related issue: https://github.com/TrenchBoot/trenchboot-issues/issues/82